### PR TITLE
Change: 路線詳細ページの各列車の詳細の内容

### DIFF
--- a/src/app/line-detail/line-detail.component.html
+++ b/src/app/line-detail/line-detail.component.html
@@ -13,7 +13,7 @@
             rapid: train.displayType == '快速',
             regional: train.displayType == '区間快速',
             yamatoji: train.displayType == '大和路快',
-            miyakoji: train.displayType == 'みやこ路快',
+            miyakoji: train.displayType == 'みやこ路快速',
             kixkishu: train.displayType == '関空紀州',
             kix: train.displayType == '関空快速',
             kishu: train.displayType == '紀州路快',
@@ -23,9 +23,9 @@
           class="type"
         >
           {{ train.displayType }}
-          <ng-container *ngIf="train.typeChange">
+         <!-- <ng-container *ngIf="train.typeChange">
             <span class="type-change-text"> ({{ train.typeChange }}) </span>
-          </ng-container>
+          </ng-container> -->
         </span>
         <span *ngIf="train.nickname">
           {{ train.nickname }}
@@ -44,15 +44,23 @@
         <span *ngIf="train.numberOfCars">({{ train.numberOfCars }}両)</span>
       </div>
       <div mat-line>{{ train.positionText }} {{ train.directionText }}</div>
-      <div mat-line *ngIf="train.delayMinutes != 0" class="delay">
+      <div mat-line *ngIf="train.delayMinutes != 0">
         <ng-container *ngIf="train.delayMinutes == 61" class="over-delay">
           1時間以上遅れ
         </ng-container>
-        <ng-container *ngIf="train.delayMinutes != 61">
+        <ng-container *ngIf="train.delayMinutes != 61" class="delay">
           {{ train.delayMinutes }}分遅れ
         </ng-container>
       </div>
       <div mat-line *ngIf="train.delayMinutes == 0">定刻</div>
+      <ng-container [ngSwitch]="train.typeChange" class="type-change-text">
+        <div *ngSwitchCase="'「Ａシート」は9号車（有料座席）'">
+          備考：{{ train.typeChange }}
+        </div>
+        <div *ngSwitchCase="'運転日により停車駅が異なります'">
+          備考：{{ train.typeChange }}
+        </div>
+      </ng-container>
     </mat-list-item>
   </ng-container>
 </mat-list>


### PR DESCRIPTION
モバイル端末で閲覧した際に、 `train.typeChange` に長い文字列が入っていると行先が見切れる問題があったので対応しました。